### PR TITLE
Move action server definition to masdif override file

### DIFF
--- a/.github/workflows/rasa.yml
+++ b/.github/workflows/rasa.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: '*'
 env:
-  RASA_VERSION: 3.4.2
+  RASA_VERSION: 3.4.9
   FUSEKI_VERSION: 4.7.0
   FUSEKI_NETWORK_HOST: localhost
   FUSEKI_NETWORK_PORT: 3030
@@ -47,7 +47,7 @@ jobs:
         # Use our own fork of the seemingly unmaintained RasaHQ gha
         uses: SDiFI/rasa-train-test-gha@sdifi
         with:
-          rasa_version: '3.4.2'
+          rasa_version: ${{ env.RASA_VERSION }}
           data_validate: true # Validates domain and data files to check for possible mistakes
           rasa_train: true # Run rasa train
           rasa_test: true # Run rasa test

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ RASA_TOKEN=<some_rasa_token>              # Access token for using the Restful A
 RABBITMQ_PASSWORD=<some_rabbitmq_passwd>  # Password to use for RabbitMQ
 DB_PASSWORD=<some_database_passwd>        # PostgreSQL password
 RASA_TELEMETRY_ENABLED=false              # Set to true in case you want to send anonymous usage data to Rasa
-DEBUG_MODE=true                           # Set to false, if you don't want lots of infomration from Rasa
-FUSEKI_VERSION=4.7.0
+DEBUG_MODE=true                           # Set to false, if you don't want lots of information from Rasa
+FUSEKI_VERSION=4.7.0                      # set version of Fuseki, the RDF knowledge base used in rasa actions
 ```
 You can also use the provided `.env.template` file as an example.
 

--- a/docker/sdk/Dockerfile
+++ b/docker/sdk/Dockerfile
@@ -1,4 +1,4 @@
-FROM rasa/rasa-sdk:3.4.0
+FROM rasa/rasa-sdk:3.4.1
 USER root
 RUN pip install --upgrade pip
 RUN pip install --no-cache-dir --default-timeout=100 islenska==0.4.5

--- a/masdif_override_template.yml
+++ b/masdif_override_template.yml
@@ -21,13 +21,13 @@
     command: chown -R 1000:1000 /tmp/fuseki-data
 
   fuseki:
-    # These final two services are the only ones that need to be built via docker-compose build
     build:
       # adapt build context according to your project structure, the following context is used, if you have
       # mounted this project inside the subdirectory `rasa/`
       context: rasa/
       dockerfile: ./docker/fuseki/Dockerfile
     image: ${REGISTRY_URL:-}fuseki-${FUSEKI_VERSION}:${APPLICATION_VERSION:-latest}
+    restart: unless-stopped
     expose:
       - "3030"
     #volumes:
@@ -37,3 +37,18 @@
     #depends_on:
     #  fuseki-init:
     #    condition: service_completed_successfully
+
+  action_server:
+    build:
+      # adapt build context according to your project structure, the following context is used, if you have
+      # mounted this project inside subdirectory `rasa/`
+      context: rasa/
+      dockerfile: ./docker/sdk/Dockerfile
+    image: ${REGISTRY_URL:-}municipal_actions:${APPLICATION_VERSION:-latest}
+    restart: unless-stopped
+    expose:
+      - "5055"
+    depends_on:
+      - rasa
+    env_file:
+      - .env


### PR DESCRIPTION
- `masdif_override_template.yml`: move action_server part to here. This is the more logical place instead of being integrated inside the  `docker-compose.yml` file of Masdif
- add fuseki service restart policy
- workflows/rasa.yml: update to Rasa version `3.4.9`. Also bump `rasa-sdk` dependency to `3.4.1` and correct some Documentation