### PR TITLE
Ba add motd action

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,11 @@ You can also use the provided `.env.template` file as an example.
 Currently, the docker-compose setup is only meant for running a Rasa instance with an already trained model
 from the directory `./models`. To train a model, the local development method should be used before starting Rasa
 in this way (see further down). Rasa always uses the model with the latest timestamp in case multiple model files exist
-inside `models/`
+inside `models/` You should also create a `cache/` folder inside your repo and change permissions with:
+
+```bash
+chmod 777 cache/
+```
 
 After training, run the following commands: (docker-compose needs to be installed):
 
@@ -75,6 +79,23 @@ docker exec -it fuseki_server rm -rf databases/DB2/Data-0001/
 docker-compose run --rm  -v $(pwd)/rdf:/fuseki/rdf/ --entrypoint="sh /fuseki/scripts/db_init.sh /fuseki/rdf/updated_kb.rdf" fuseki
 # Start the containers again
 ```
+
+### Trigger intent via endpoint
+
+With all servers up and running, all intents can be triggered via the ```trigger_intent``` endpoint of your Rasa
+conversation. For instance, we include an intent for retrieving the 'MOTD' (Message-of-the-day) greeting, which are 
+stored in the [motd.yml](data/motd/motd.yml) file. Different bot greetings are produced for different given dates and 
+languages. 
+
+This intent can be triggered, and English passed as the ```language``` entity, with a request like:
+
+``` bash
+curl -X POST http://localhost:5005/conversations/conversation_id/trigger_intent?token=RASA_TOKEN -H 'application/json' -d '{"name":"motd", "entities": {"language": "en-EN"}}' 
+```
+
+where ```conversation\_id``` is the id of your current conversation, found in the Rasa server, and ```RASA_TOKEN```
+is the one defined in your `.env` file.
+
 
 ### Local development with Rasa
 
@@ -224,6 +245,9 @@ Currently, the system can identify the following intents:
   * ask about the weather
 * faq:
   * population of Andabær
+  
+The intent 'motd' is also included, but has no training data as it is not meant to be 
+triggered through a message from the user (see 'Trigger intent via endpoint').
 
 ## Knowledge base
 

--- a/actions/actions.py
+++ b/actions/actions.py
@@ -60,7 +60,7 @@ class ActionGetMOTD(Action):
             output_dict["motd"] = {"language": language, "motd": motd_list}
         else:
             output_dict["motd"] = {"language": language, "motd": default_message_list}
-        return [BotUttered(json.dumps(output_dict))]
+        return [BotUttered(json.dumps(output_dict, ensure_ascii=False).encode('utf8').decode())]
 
 
 class ActionDefaultAskAffirmation(Action):

--- a/actions/actions.py
+++ b/actions/actions.py
@@ -25,7 +25,8 @@ logger = logging.getLogger(__name__)
 
 
 class ActionGetMOTD(Action):
-    """Retrieve mot-of-the-day greeting from external file."""
+    """Retrieve message-of-the-day greeting from external file.
+    Only meant to be triggered remotely, not from a user message."""
 
     def name(self) -> Text:
         return "action_get_motd"
@@ -53,6 +54,8 @@ class ActionGetMOTD(Action):
             elif 'default' in item:
                 for message in item['messages'][language]:
                     default_message_list.append(message)
+        # If no messages are found for the current date,
+        # use the default message for the given language.
         if len(motd_list) != 0:
             output_dict["motd"] = {"language": language, "motd": motd_list}
         else:

--- a/data/motd/motd.yml
+++ b/data/motd/motd.yml
@@ -7,7 +7,7 @@ motd:
         - Hallo! Montag ist ein frischer Start.
         - Womit kann ich Ihnen heute behilflich sein?
       is-IS:
-        - Hæ! Mánudagur er ný byrjun.
+        - Hæ! Mánudagur markar nýtt upphaf.
         - Hvað get ég hjálpað þér með í dag?
       en-EN:
         - Hello! Monday is a fresh start.
@@ -20,7 +20,7 @@ motd:
         - Hallo! Der Mai bringt Wachstum und Erneuerung.
         - Womit kann ich Ihnen heute behilflich sein?
       is-IS:
-        - Hæ! Maí færir vöxt og endurvæðingu.
+        - Hæ! Maí færir vöxt og endurnýjun.
         - Hvað get ég aðstoðað þig með í dag?
       en-EN:
         - Hello! May brings growth and renewal.

--- a/data/motd/motd.yml
+++ b/data/motd/motd.yml
@@ -1,0 +1,35 @@
+motd:
+  - date_range:
+      start: 2023-04-24
+      end: 2023-04-24
+    messages:
+      de-DE:
+        - Hallo! Montag ist ein frischer Start.
+        - Womit kann ich Ihnen heute behilflich sein?
+      is-IS:
+        - Hæ! Mánudagur er ný byrjun.
+        - Hvað get ég hjálpað þér með í dag?
+      en-EN:
+        - Hello! Monday is a fresh start.
+        - What can I help you with today?
+  - date_range:
+      start: 2023-05-01
+      end: 2023-05-07
+    messages:
+      de-DE:
+        - Hallo! Der Mai bringt Wachstum und Erneuerung.
+        - Womit kann ich Ihnen heute behilflich sein?
+      is-IS:
+        - Hæ! Maí færir vöxt og endurvæðingu.
+        - Hvað get ég aðstoðað þig með í dag?
+      en-EN:
+        - Hello! May brings growth and renewal.
+        - What can I assist you with today?
+  - default:
+    messages:
+      de-DE:
+        - Guten Tag! Ich bin Ihr Chatbot. Wie kann ich Ihnen heute helfen?
+      is-IS:
+        - Góðan dag! Ég er spjallforritið þitt. Hvernig get ég aðstoðað þig í dag?
+      en-EN:
+        - Good day! I'm your chatbot. How can I assist you today?

--- a/data/rules.yml
+++ b/data/rules.yml
@@ -17,7 +17,7 @@ rules:
   - intent: bye
   - action: utter_bye
 
-- rule: Return MOTD (Mot of the day)
+- rule: Return MOTD (Message of the day)
   steps:
   - intent: motd
   - action: action_get_motd

--- a/data/rules.yml
+++ b/data/rules.yml
@@ -17,6 +17,11 @@ rules:
   - intent: bye
   - action: utter_bye
 
+- rule: Return MOTD (Mot of the day)
+  steps:
+  - intent: motd
+  - action: action_get_motd
+
 - rule: Respond to out-of-scope request
   steps:
   - intent: out_of_scope

--- a/docker/sdk/Dockerfile
+++ b/docker/sdk/Dockerfile
@@ -2,11 +2,13 @@ FROM rasa/rasa-sdk:3.4.1
 USER root
 RUN pip install --upgrade pip
 RUN pip install --no-cache-dir --default-timeout=100 islenska==0.4.5
+RUN pip install --no-cache-dir pyyaml==6.0
 RUN pip install --no-cache-dir requests==2.26.0
 
 RUN mkdir -p /app/src
 COPY actions/actions.py /app/actions/actions.py
 COPY src/ /app/src
+COPY data/motd/motd.yml /app/data/motd/motd.yml
 
 ENV PYTHONPATH "${PYTHONPATH}:/app/src/municipal_info_api"
 

--- a/domain.yml
+++ b/domain.yml
@@ -17,6 +17,7 @@ intents:
     is_retrieval_intent: true
 - bye
 - thank
+- motd
 #- stop
 #- affirm
 #- deny
@@ -26,6 +27,7 @@ entities:
 - subject
 - title
 - pronoun
+- language
 slots:
   contact:
     type: text
@@ -57,6 +59,12 @@ slots:
     mappings:
     - type: from_entity
       entity: email_or_phone
+  language:
+    type: text
+    influence_conversation: false
+    mappings:
+      - type: from_entity
+        entity: language
   contacts_found:
     type: bool
     influence_conversation: False
@@ -214,6 +222,7 @@ actions:
 - action_default_ask_affirmation
 - action_get_whois
 - action_get_operator
+- action_get_motd
 forms:
   request_contact_form:
     ignored_intents:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,15 @@
 # For actions
 islenska==0.4.6
+pyyaml==6.0
 requests==2.28.2
 
 # Rasa dependencies
+freezegun==1.2.2
 keras==2.8.0
 Keras-Preprocessing==1.1.2
 numpy==1.22.4
 pytest==7.2.1
+pytest-asyncio==0.21.0
 rdflib==6.3.2
 rasa==3.4.9
 rasa-sdk==3.4.1

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -1,12 +1,13 @@
 """Unit tests for custom actions."""
 import pytest
+from freezegun import freeze_time
 from typing import Text, Any
 from rdflib import Graph
 
 from rasa_sdk.executor import CollectingDispatcher
 from rasa_sdk import Tracker
 from rasa_sdk.types import DomainDict
-from rasa_sdk.events import SlotSet, AllSlotsReset
+from rasa_sdk.events import SlotSet, AllSlotsReset, BotUttered
 
 from actions import actions
 
@@ -179,3 +180,37 @@ def test_get_operator_no_phone(
     g.parse("./src/municipal_info_api/offices_staff.rdf")
     data = g.serialize(format="xml")
     info_api.update_db(data_string=data, data_type='RDF')
+
+
+@pytest.mark.parametrize(
+    "language, date, expected_events",
+    [
+        ("de-DE", "2023-04-24",
+         [BotUttered('{"motd": {"language": "de-DE", '
+                     '"motd": ["Hallo! Montag ist ein frischer Start.", '
+                     '"Womit kann ich Ihnen heute behilflich sein?"]}}')]),
+        ("de-DE", "2023-05-05",
+         [BotUttered('{"motd": {"language": "de-DE", '
+                     '"motd": ["Hallo! Der Mai bringt Wachstum und Erneuerung.", '
+                     '"Womit kann ich Ihnen heute behilflich sein?"]}}')]),
+        ("en-EN", "2023-04-27",
+         [BotUttered('{"motd": {"language": "en-EN", '
+                     '"motd": ["Good day! I\'m your chatbot. How can I assist you today?"]}}')])
+    ]
+)
+@pytest.mark.asyncio
+async def test_get_motd(
+        tracker: Tracker,
+        dispatcher: CollectingDispatcher,
+        domain: DomainDict,
+        language: Text,
+        date: Text,
+        expected_events: Any
+):
+    tracker.slots["language"] = language
+    freezer = freeze_time(date)
+    freezer.start()
+    actual_events = await actions.ActionGetMOTD().run(dispatcher=dispatcher, tracker=tracker, domain=domain)
+    freezer.stop()
+
+    assert actual_events == expected_events

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -185,10 +185,10 @@ def test_get_operator_no_phone(
 @pytest.mark.parametrize(
     "language, date, expected_events",
     [
-        ("de-DE", "2023-04-24",
-         [BotUttered('{"motd": {"language": "de-DE", '
-                     '"motd": ["Hallo! Montag ist ein frischer Start.", '
-                     '"Womit kann ich Ihnen heute behilflich sein?"]}}')]),
+        ("is-IS", "2023-04-24",
+         [BotUttered('{"motd": {"language": "is-IS", '
+                     '"motd": ["H\\u00e6! M\\u00e1nudagur markar n\\u00fdtt upphaf.", '
+                     '"Hva\\u00f0 get \\u00e9g hj\\u00e1lpa\\u00f0 \\u00fe\\u00e9r me\\u00f0 \\u00ed dag?"]}}')]),
         ("de-DE", "2023-05-05",
          [BotUttered('{"motd": {"language": "de-DE", '
                      '"motd": ["Hallo! Der Mai bringt Wachstum und Erneuerung.", '

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -187,8 +187,8 @@ def test_get_operator_no_phone(
     [
         ("is-IS", "2023-04-24",
          [BotUttered('{"motd": {"language": "is-IS", '
-                     '"motd": ["H\\u00e6! M\\u00e1nudagur markar n\\u00fdtt upphaf.", '
-                     '"Hva\\u00f0 get \\u00e9g hj\\u00e1lpa\\u00f0 \\u00fe\\u00e9r me\\u00f0 \\u00ed dag?"]}}')]),
+                     '"motd": ["Hæ! Mánudagur markar nýtt upphaf.", '
+                     '"Hvað get ég hjálpað þér með í dag?"]}}')]),
         ("de-DE", "2023-05-05",
          [BotUttered('{"motd": {"language": "de-DE", '
                      '"motd": ["Hallo! Der Mai bringt Wachstum und Erneuerung.", '


### PR DESCRIPTION
Closes #42.

Adds custom action `ActionGetMOTD` which is meant to be run by triggering the `motd` intent via the `trigger_intent` endpoint.

Retrieves the appropriate MOTD greeting from the file `data/motd/motd.yml`, based on the current date and the language passed to the endpoint.