### PR TITLE
config.yml: change model weights to grammatek/icelandic-ner-bert

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -14,7 +14,7 @@ pipeline:
 #   model_name: "convbert"
 #   model_weights: "jonfd/convbert-base-igc-is"
    model_name: "bert"
-   model_weights: "m3hrdadfi/icelandic-ner-bert"
+   model_weights: "grammatek/icelandic-ner-bert"
  - name: DIETClassifier
    epochs: 100
  - name: FallbackClassifier


### PR DESCRIPTION
The original model weights had been removed from the author. We cloned the repository beforehand and added it to the grammatek huggingface page.