### PR TITLE
Add custom NER component.

### DIFF
--- a/.github/workflows/rasa.yml
+++ b/.github/workflows/rasa.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Run PyTest
         run: |
           source venv/bin/activate
-          export PYTHONPATH="`pwd`/src/municipal_info_api"
+          export PYTHONPATH="`pwd`:`pwd`/src/municipal_info_api"
           pytest -s -v --junitxml=report.xml .
           touch report.xml
       - name: Publish PyTest Report

--- a/.github/workflows/rasa.yml
+++ b/.github/workflows/rasa.yml
@@ -17,9 +17,13 @@ env:
 jobs:
   training-testing:
     name: Training and Testing
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: 3.9.10
       - name: Install dependencies
         run: |
           python3 -m venv venv

--- a/README.md
+++ b/README.md
@@ -249,6 +249,27 @@ Currently, the system can identify the following intents:
 The intent 'motd' is also included, but has no training data as it is not meant to be 
 triggered through a message from the user (see 'Trigger intent via endpoint').
 
+## BÍN Entity Extraction
+
+We have implemented an experimental entity extractor as a Rasa custom component that uses the BÍN database to extract
+entities from the user input.
+This extractor is currently disabled by default, but can be enabled by placing the configuration snippet
+[bin_config.yml](classifiers/bin_config.yml) below the DIETClassifier configuration into the file [config.yml](config.yml])`.
+
+The idea is to use the BÍN database to extract entities that are not covered by the DIETClassifier, such as names of
+people, places, etc. The BÍN database is a large database of Icelandic words, their inflections and their grammatical
+properties. The BÍN entity extractor can be customized to use mappings of entities to certain BÍN properties as
+described [here](https://bin.arnastofnun.is/gogn/storasnid/ord/). One should also carefully place stop-words into the
+`stop_words` configuration parameter to avoid extracting entities that are not relevant or that are ambiguous as e.g.
+`á, dag, ...`
+
+It should be placed behind all other entity extractors in the Rasa pipeline and be configured to either ignore or
+replace already extracted entities, otherwise it will append the BÍN entities to the already extracted entities which
+leads to double extracted entities. It can also be configured via the parameter `match_training_data` to extract only
+entities that are labelled and where the user text closely follows the training data.
+
+Please refer to the BÍN entity extractor configuration snippet for further details.
+
 ## Knowledge base
 
 The knowledge base is initialised via an RDF document (`src/municipal_info_api/offices_staff.rdf`) and uses the following ontologies:

--- a/classifiers/bin_config.yml
+++ b/classifiers/bin_config.yml
@@ -1,0 +1,42 @@
+# Icelandic entity extractor based on the BÍN database. Please place the contents of this file after all other entity
+# extractor definitions in your Rasa pipeline config (config.yml).
+
+- name: classifiers.bin_entity_extractor.BinEntityExtractor
+  enable: false
+  # 'match_training_data' takes into account only sentences that are present inside the training data. The unlabelled
+  # sentence parts of the training data are used as a regex matcher against the tested sentence and the labelled part
+  # is used to find the appropriate entity. This setting can be thought of as a kind of regex entity extractor, but on a
+  # whole sentence basis instead of a token basis and uses all training sentences as regexes.
+  # This flag is useful to augment entity extractors further up in the pipeline. If set to 'true', this flag takes
+  # precedence over the 'match_all_entities' flag.
+  # Mandatory. Default: false
+  match_training_data: true
+  # 'match_all_entities' takes into account any entities found inside the given sentence. This can often lead to false
+  # positives and should be accompanied by appropriate 'stop_words' and 'entity_mappings' settings.
+  # If set to 'true', this flag is overriden by the 'match_training_data' flag.
+  # Mandatory. Default: false
+  match_all_entities: false
+  # This flag allows you to specify a mapping of entity labels of the training data to BÍN entity types. The purpose is
+  # to restrict the matching to only a relevant subset of entities. This is useful to avoid false positives.
+  # Mandatory. Default: {}
+  entity_mappings:
+    city: ['bær', 'þor']
+    contact: ['ism', 'gæl', 'föð', 'móð', 'erm']
+    place: ['fyr', 'göt', 'örn']
+  # This flag allows you to specify a list of stop words that should be ignored when matching entities with the
+  # BÍN entity extractor. This is useful to avoid false positives especially inside the test data. In case of
+  # setting the flag 'match_all_entities' to 'true', this configuration needs to be carefully chosen, otherwise it can
+  # lead to a lot of false positives
+  # Default: []
+  stop_words: ['á', 'dag', 'tala']
+  # The extraction mode determines how the BÍN entity extractor should be used when an entity has already been extracted
+  # by a previous pipeline step.
+  # There are three modes available:
+  # - 'append':             The BÍN entity extractor is used as an additional entity extractor. This means that the
+  #                         entities found by the BÍN entity extractor are added to the entities found by the previous
+  #                         entity extractors.
+  # - 'overwrite':          The BÍN entity extractor overwrites the entities found by the previous entity extractors in
+  #                         case of a conflict.
+  # - 'skip': [recommended] The BÍN entity extractor is skipped and the entities found by the previous entity extractors
+  #                         are kept in case of a conflict.
+  extraction_mode: 'skip'

--- a/classifiers/bin_entity_extractor.py
+++ b/classifiers/bin_entity_extractor.py
@@ -1,0 +1,184 @@
+"""
+A custom entity extractor that uses the BÍN database and tagset
+to look up possible named entities. Can be configured to extract
+all words which are labeled with some NER-tag in BÍN or only in cases
+where the user message matches some example from our training data
+with some new term instead of the labeled entity in the training data.
+"""
+
+from typing import Dict, Text, Any, List
+import yaml
+import re
+
+from rasa.engine.graph import GraphComponent, ExecutionContext
+from rasa.engine.recipes.default_recipe import DefaultV1Recipe
+from rasa.engine.storage.resource import Resource
+from rasa.engine.storage.storage import ModelStorage
+from rasa.shared.nlu.training_data.message import Message
+from rasa.shared.exceptions import InvalidConfigException
+from rasa.nlu.extractors.extractor import EntityExtractorMixin
+from rasa.shared.core.domain import Domain
+
+from islenska import Bin
+
+ALL_BIN_TAGS = ["heö", "alm", "ism", "föð", "móð", "fyr", "bibl", "gæl", "lönd", "gras", "efna", "tölv", "lækn",
+                "örn", "tón", "natt", "göt", "lög", "íþr", "málfr", "tími", "við", "fjár", "bíl", "ffl", "mat",
+                "bygg", "tung", "erl", "hetja", "bær", "þor", "mvirk", "brag", "jard", "stærð", "hug", "erm",
+                "mæl", "titl", "gjald", "stja", "dýr", "hann", "ætt", "ob", "entity", "spurn"]
+
+
+@DefaultV1Recipe.register(
+    [DefaultV1Recipe.ComponentType.ENTITY_EXTRACTOR], is_trainable=False
+)
+class BinEntityExtractor(GraphComponent, EntityExtractorMixin):
+
+    def __init__(self, component_config: Dict[Text, Any]) -> None:
+        self.component_config = component_config
+        self.validate_component_config(component_config=self.component_config)
+
+    @staticmethod
+    def nlu_examples() -> Dict:
+        with open('data/nlu.yml', 'r') as stream:
+            examples = yaml.safe_load(stream)
+        return examples
+
+    @classmethod
+    def create(
+        cls,
+        config: Dict[Text, Any],
+        model_storage: ModelStorage,
+        resource: Resource,
+        execution_context: ExecutionContext,
+    ) -> GraphComponent:
+        return cls(config)
+
+    @classmethod
+    def validate_component_config(cls, component_config: Dict[Text, Any]) -> None:
+        if "match_training_data" not in component_config:
+            raise InvalidConfigException(
+                f"your configuration should contain the section 'match_training_data' and a value of true or false. "
+                f"Please specify whether the featurizer should be used only when user input matches an example "
+                f"from your training data, with different entities"
+            )
+        if component_config["match_training_data"] not in [True, False]:
+            raise InvalidConfigException(
+                f"your configuration should contain the section 'match_training_data' and a value of true or false. "
+                f"Please specify whether the featurizer should be used only when user input matches an example "
+                f"from your training data, with different entities"
+            )
+        if "match_all_entities" not in component_config:
+            raise InvalidConfigException(
+                f"your configuration should contain the section 'match_all_entities' and a value of true or false. "
+                f"Please specify whether the featurizer should return all possible matches according to a Bín-lookup."
+                f"(If match_training_data is set to True, this is only done as a backup in case of no matches)"
+            )
+        if component_config["match_all_entities"] not in [True, False]:
+            raise InvalidConfigException(
+                f"your configuration should contain the section 'match_all_entities' and a value of true or false. "
+                f"Please specify whether the featurizer should return all possible matches according to a Bín-lookup."
+                f"(If match_training_data is set to True, this is only done as a backup in case of no matches)"
+            )
+        if "entity_mappings" not in component_config:
+            raise InvalidConfigException(
+                f"your configuration is missing the section 'entity mappings', "
+                f"which should contain mappings of Bin tags to slots in your domain, "
+                f"e.g. contact:- ism"
+            )
+        bin_entity_tags = component_config["entity_mappings"]
+        for key in bin_entity_tags.keys():
+            domain = Domain.load("domain.yml")
+            domain_dict = domain.as_dict()
+            if key not in domain_dict["entities"]:
+                raise InvalidConfigException(
+                    f"{key} is listed as a slot mapping in your configuration "
+                    f"but not as a valid slot in your domain."
+                )
+            for tag in bin_entity_tags[key]:
+                if tag not in ALL_BIN_TAGS:
+                    raise InvalidConfigException(
+                        f"{tag} is listed as a possible tag in your configuration "
+                        f"but does not exist in the Bin tagset."
+                    )
+
+    def process(self, messages: List[Message], **kwargs: Any) -> List[Message]:
+        for message in messages:
+            extracted = None
+            tokens = message.data["text_tokens"]
+            intent = message.get("intent")
+            message_text = message.get("text")
+            if self.component_config["match_training_data"]:
+                # Check whether user message matches example in training data exactly,
+                # but with labeled entity replaced with new entity
+                matched_nlu_tokens = self.nlu_example_match(tokens, intent, message_text)
+                extracted = self._match_entities(matched_nlu_tokens)
+            if self.component_config["match_all_entities"]:
+                if not extracted:
+                    extracted = self._match_entities(tokens)
+            for entity in message.get("entities"):
+                if not extracted or extracted[0]["value"] in entity["value"]:
+                    return messages
+            message.set("entities", message.get("entities", []) + extracted, add_to_output=True)
+        return messages
+
+    def _match_entities(self, tokens: List) -> List:
+        extracted_entities = []
+        matched_tag = None
+        for token in tokens:
+            tag, confidence = self.bin_lookup_tag(token.text)
+            if tag:
+                # Check whether the last token was also matched as an entity with the same tag,
+                # in that case assume a multi-word token and concatenate.
+                if matched_tag == tag:
+                    extracted_entities[-1]["value"] += f" {token.text}"
+                    extracted_entities[-1]["end"] = token.end
+                else:
+                    match = {
+                        "start": token.start,
+                        "end": token.end,
+                        "value": token.text,
+                        "confidence": confidence,
+                        "entity": tag,
+                        "extractor": self.name
+                    }
+                    extracted_entities.append(match)
+                    matched_tag = tag
+            else:
+                matched_tag = None
+        return extracted_entities
+
+    def nlu_example_match(self, tokens: List, intent: Text, message_text: Text) -> List:
+        entity_tokens = []
+        for nlu_entry in self.nlu_examples()['nlu']:
+            if 'intent' in nlu_entry and nlu_entry['intent'] == intent['name']:
+                for intent_example in nlu_entry['examples'].split('\n'):
+                    entity_type_matches = re.findall(r'\[(.*?)\][\{\(](.*?)[\)\}]', intent_example)
+                    if entity_type_matches:
+                        example_string = re.sub(r'\[(.*?)\][\{\(](.*?)[\)\}]', '(.*?)', intent_example)
+                        example_string = example_string.removeprefix('- ')
+                        if example_string.endswith('?'):
+                            example_string = re.sub(r"\?$", r"\?", example_string)
+                        re_match = re.search(example_string, message_text)
+                        if re_match:
+                            for i, match in enumerate(re_match.groups()):
+                                start = message_text[:re_match.start(i + 1)].count(' ')
+                                end = start + match.count(' ') + 1
+                                matched_tokens = tokens[start:end]
+                                for token in matched_tokens:
+                                    entity_tokens.append(token)
+                            return entity_tokens
+        return entity_tokens
+
+    def bin_lookup_tag(self, token: Text) -> Any:
+        b = Bin()
+        attributes = []
+        bin_entity_tags = self.component_config["entity_mappings"]
+        for option in [token.lower(), token.title()]:
+            w, attr = b.lookup(option)
+            if attr:
+                attributes.append(attr)
+        confidence = 1.0/len(attributes) if attributes else 1.0
+        for key in bin_entity_tags.keys():
+            for entry in attributes:
+                if entry[0].hluti in bin_entity_tags[key]:
+                    return key, confidence
+        return None, None

--- a/classifiers/bin_entity_extractor.py
+++ b/classifiers/bin_entity_extractor.py
@@ -1,14 +1,18 @@
-"""
-A custom entity extractor that uses the BÍN database and tagset
-to look up possible named entities. Can be configured to extract
-all words which are labeled with some NER-tag in BÍN or only in cases
-where the user message matches some example from our training data
-with some new term instead of the labeled entity in the training data.
-"""
+# BÍN entity extractor. This extractor uses the BÍN database to extract entities from the user input.
+# The BÍN database is a database of Icelandic words and their inflections. This extractor is useful
+# for extracting entities that are not in the training data or are inflections of entities that are in the
+# training data. For example, if the user asks for the mayor of a town that is in the training data but uses a
+# different inflection, this extractor will extract the entity.
+# If placed inside the pipeline behind other entity extractors, this extractor will only extract entities which are not
+# already extracted.
+#
+# Note: This entity extractor does not rely on any featurizer as it extracts features on its own.
 
 from typing import Dict, Text, Any, List
-import yaml
+import logging
+import string
 import re
+import yaml
 
 from rasa.engine.graph import GraphComponent, ExecutionContext
 from rasa.engine.recipes.default_recipe import DefaultV1Recipe
@@ -21,10 +25,13 @@ from rasa.shared.core.domain import Domain
 
 from islenska import Bin
 
+# see https://bin.arnastofnun.is/gogn/storasnid/ord/
 ALL_BIN_TAGS = ["heö", "alm", "ism", "föð", "móð", "fyr", "bibl", "gæl", "lönd", "gras", "efna", "tölv", "lækn",
                 "örn", "tón", "natt", "göt", "lög", "íþr", "málfr", "tími", "við", "fjár", "bíl", "ffl", "mat",
                 "bygg", "tung", "erl", "hetja", "bær", "þor", "mvirk", "brag", "jard", "stærð", "hug", "erm",
                 "mæl", "titl", "gjald", "stja", "dýr", "hann", "ætt", "ob", "entity", "spurn"]
+
+logger = logging.getLogger(__name__)
 
 
 @DefaultV1Recipe.register(
@@ -35,25 +42,30 @@ class BinEntityExtractor(GraphComponent, EntityExtractorMixin):
     def __init__(self, component_config: Dict[Text, Any]) -> None:
         self.component_config = component_config
         self.validate_component_config(component_config=self.component_config)
+        self.domain = Domain.load("domain.yml")
 
     @staticmethod
     def nlu_examples() -> Dict:
         with open('data/nlu.yml', 'r') as stream:
             examples = yaml.safe_load(stream)
-        return examples
+        return examples['nlu']
 
     @classmethod
     def create(
-        cls,
-        config: Dict[Text, Any],
-        model_storage: ModelStorage,
-        resource: Resource,
-        execution_context: ExecutionContext,
+            cls,
+            config: Dict[Text, Any],
+            model_storage: ModelStorage,
+            resource: Resource,
+            execution_context: ExecutionContext,
     ) -> GraphComponent:
         return cls(config)
 
     @classmethod
     def validate_component_config(cls, component_config: Dict[Text, Any]) -> None:
+        if "enable" not in component_config or not component_config["enable"]:
+            logger.info("BÍN Entity extractor: disabled")
+            return
+
         if "match_training_data" not in component_config:
             raise InvalidConfigException(
                 f"your configuration should contain the section 'match_training_data' and a value of true or false. "
@@ -84,6 +96,25 @@ class BinEntityExtractor(GraphComponent, EntityExtractorMixin):
                 f"which should contain mappings of Bin tags to slots in your domain, "
                 f"e.g. contact:- ism"
             )
+        else:
+            logger.info("Rasa/BÍN Entity mappings: " + str(component_config["entity_mappings"]))
+
+        if "stop_words" not in component_config:
+            logger.warning("No stop words specified. This may lead to false positives.")
+
+        if "extraction_mode" not in component_config:
+            raise InvalidConfigException(
+                f"your configuration is missing the section 'extraction_mode', "
+                f"which should contain the extraction mode, either 'append', 'overwrite' or 'skip'"
+            )
+        if component_config["extraction_mode"] not in ['append', 'overwrite', 'skip']:
+            raise InvalidConfigException(
+                f"your configuration should contain the section 'extraction_mode' and a value of 'append', 'overwrite' "
+                f"or 'skip'. Please specify whether the featurizer should append, overwrite or skip entities that "
+                f"are already extracted."
+            )
+        logger.info("BÍN Entity extractor: extraction mode: " + str(component_config["extraction_mode"]))
+
         bin_entity_tags = component_config["entity_mappings"]
         for key in bin_entity_tags.keys():
             domain = Domain.load("domain.yml")
@@ -100,33 +131,55 @@ class BinEntityExtractor(GraphComponent, EntityExtractorMixin):
                         f"but does not exist in the Bin tagset."
                     )
 
+    @classmethod
+    def find_entity_with_value(cls, dicts: List[Dict[Text, Any]], value: Text):
+        for d in dicts:
+            if value in d.values():
+                return d
+        return None
+
     def process(self, messages: List[Message], **kwargs: Any) -> List[Message]:
+        is_enabled = self.component_config.get("enabled", True)
+        if not is_enabled:
+            return messages
+
+        stop_words = self.component_config.get("stop_words", [])
+        extraction_mode = self.component_config.get("extraction_mode")
+
         for message in messages:
-            extracted = None
+            # logger.info("BÍN Entity extractor: processing message: " + str(message.data))
             tokens = message.data["text_tokens"]
             intent = message.get("intent")
             message_text = message.get("text")
+
+            # Check whether user message matches example in training data exactly,
+            # but with labeled entity replaced with new entity
             if self.component_config["match_training_data"]:
-                # Check whether user message matches example in training data exactly,
-                # but with labeled entity replaced with new entity
-                matched_nlu_tokens = self.nlu_example_match(tokens, intent, message_text)
-                extracted = self._match_entities(matched_nlu_tokens)
-            if self.component_config["match_all_entities"]:
-                if not extracted:
-                    extracted = self._match_entities(tokens)
-            for entity in message.get("entities"):
-                if not extracted or extracted[0]["value"] in entity["value"]:
-                    return messages
-            message.set("entities", message.get("entities", []) + extracted, add_to_output=True)
+                # overwrite tokens with detected tokens from training examples
+                tokens = self.nlu_example_match(tokens, intent, message_text)
+            extracted = self._match_entities(tokens, stop_words)
+            if extracted:
+                if extraction_mode == 'append':
+                    message.set("entities", message.get("entities", []) + extracted, add_to_output=True)
+                else:
+                    entities = message.get("entities")
+                    d = BinEntityExtractor.find_entity_with_value(entities, extracted[0]["value"])
+                    if d is not None:
+                        if extraction_mode == 'skip':
+                            # If the entity is already extracted, we don't want to add it to the list of entities
+                            # again, so we skip it.
+                            continue
+                        elif extraction_mode == 'overwrite':
+                            d.update(extracted[0])
+                    else:
+                        message.set("entities", message.get("entities", []) + extracted, add_to_output=True)
         return messages
 
-    def _match_entities(self, tokens: List) -> List:
+    def _match_entities(self, tokens: List, stop_words: List) -> List:
         extracted_entities = []
         matched_tag = None
         tag = None
-        stop_words = []
-        if self.component_config["use_stop_words"]:
-            stop_words = ['á', 'dag', 'tala']
+        confidence = 0.0
         for token in tokens:
             if token.text not in stop_words:
                 tag, confidence = self.bin_lookup_tag(token.text)
@@ -141,7 +194,7 @@ class BinEntityExtractor(GraphComponent, EntityExtractorMixin):
                         "start": token.start,
                         "end": token.end,
                         "value": token.text,
-                        "confidence": confidence,
+                        "confidence_entity": confidence,
                         "entity": tag,
                         "extractor": self.name
                     }
@@ -151,18 +204,38 @@ class BinEntityExtractor(GraphComponent, EntityExtractorMixin):
                 matched_tag = None
         return extracted_entities
 
-    def nlu_example_match(self, tokens: List, intent: Text, message_text: Text) -> List:
+    # Check whether user message matches example in training data exactly,
+    # but with labeled entity replaced with matchall regex. In that case, return the tokens
+    # that match the entity.
+    #
+    # Example: training example: "[email]{"entity": "email_or_phone", "value": "email"} hjá [Ástu Jónu](contact)?"
+    #          message_text: "tölvupóst hjá steinari adolfssyni"
+    #           -> matchall regex: "(.*) hjá (.*)"
+    #           -> match: "tölvupóst" and "steinari adolfssyni"
+    #           -> returned tokens [
+    #                   Token('tölvupóst', 0, 9),
+    #                   Token('steinari', 14, 22),
+    #                   Token('adolfssyni', 23, 33)
+    #               ]
+    # @param tokens: List of tokens from the user message passed to the extractor
+    # @param intent: Intent of the user message passed to the extractor
+    # @param message_text: Text of the user message passed to the extractor
+    #
+    # @return: List of tokens that match entities in the user message according to the training data
+    def nlu_example_match(self, tokens: List, intent: Any, message_text: Text) -> List:
         entity_tokens = []
-        for nlu_entry in self.nlu_examples()['nlu']:
+        LABEL_REGEX = r'\[(.*?)\][\{\(](.*?)[\)\}]'
+        REPLACE_PATTERN = '(.*)'
+        for nlu_entry in self.nlu_examples():
             if 'intent' in nlu_entry and nlu_entry['intent'] == intent['name']:
                 for intent_example in nlu_entry['examples'].split('\n'):
-                    entity_type_matches = re.findall(r'\[(.*?)\][\{\(](.*?)[\)\}]', intent_example)
-                    if entity_type_matches:
-                        example_string = re.sub(r'\[(.*?)\][\{\(](.*?)[\)\}]', '(.*?)', intent_example)
-                        example_string = example_string.removeprefix('- ')
-                        if example_string.endswith('?'):
-                            example_string = re.sub(r"\?$", r"\?", example_string)
-                        re_match = re.search(example_string, message_text)
+                    if re.findall(LABEL_REGEX, intent_example):
+                        # replace the entity label with a matchall regex, so that we can match the entity values
+                        # in the user message
+                        training_string = re.sub(LABEL_REGEX, REPLACE_PATTERN, intent_example)
+                        # remove leading dash and trailing question mark from training example
+                        training_string = training_string.removeprefix('- ').rstrip("?").rstrip()
+                        re_match = re.search(training_string, message_text)
                         if re_match:
                             for i, match in enumerate(re_match.groups()):
                                 start = message_text[:re_match.start(i + 1)].count(' ')
@@ -177,11 +250,11 @@ class BinEntityExtractor(GraphComponent, EntityExtractorMixin):
         b = Bin()
         attributes = []
         bin_entity_tags = self.component_config["entity_mappings"]
-        for option in [token.lower(), token.title()]:
-            w, attr = b.lookup(option)
-            if attr:
-                attributes.append(attr)
-        confidence = 1.0/len(attributes) if attributes else 1.0
+        # find all possible BÍN attributes for the token
+        w, attr = b.lookup(token.lower(), False, True)
+        if attr:
+            attributes.append(attr)
+        confidence = 1.0 / len(attributes) if attributes else 1.0
         for key in bin_entity_tags.keys():
             for entry in attributes:
                 if entry[0].hluti in bin_entity_tags[key]:

--- a/classifiers/bin_entity_extractor.py
+++ b/classifiers/bin_entity_extractor.py
@@ -123,8 +123,13 @@ class BinEntityExtractor(GraphComponent, EntityExtractorMixin):
     def _match_entities(self, tokens: List) -> List:
         extracted_entities = []
         matched_tag = None
+        tag = None
+        stop_words = []
+        if self.component_config["use_stop_words"]:
+            stop_words = ['á', 'dag', 'tala']
         for token in tokens:
-            tag, confidence = self.bin_lookup_tag(token.text)
+            if token.text not in stop_words:
+                tag, confidence = self.bin_lookup_tag(token.text)
             if tag:
                 # Check whether the last token was also matched as an entity with the same tag,
                 # in that case assume a multi-word token and concatenate.

--- a/classifiers/tests/test_bin_entity_extractor.py
+++ b/classifiers/tests/test_bin_entity_extractor.py
@@ -11,9 +11,10 @@ from classifiers.bin_entity_extractor import BinEntityExtractor
 config = {
     "enable": True,
     "entity_mappings": {
-        "city": ['bær'],
+        # city, place not in training data yet
+        # "city": ['bær'],
         "contact": ['ism', 'gæl', 'föð', 'móð', 'erm'],
-        "place": ['fyr', 'göt', 'þor', 'örn']
+        # "place": ['fyr', 'göt', 'þor', 'örn']
     },
     "stop_words": ['á', 'dag', 'tala'],
     "match_training_data": True,

--- a/classifiers/tests/test_bin_entity_extractor.py
+++ b/classifiers/tests/test_bin_entity_extractor.py
@@ -1,0 +1,138 @@
+"""Unit tests for BÍN entity extractor """
+
+import pytest
+
+from rasa.shared.exceptions import InvalidConfigException
+from rasa.shared.nlu.training_data.message import Message
+from rasa.nlu.tokenizers.tokenizer import Token
+
+from classifiers.bin_entity_extractor import BinEntityExtractor
+
+config = {
+    "enable": True,
+    "entity_mappings": {
+        "city": ['bær'],
+        "contact": ['ism', 'gæl', 'föð', 'móð', 'erm'],
+        "place": ['fyr', 'göt', 'þor', 'örn']
+    },
+    "stop_words": ['á', 'dag', 'tala'],
+    "match_training_data": True,
+    "match_all_entities": False,
+    "extraction_mode": "append"     # note: if you change this mode, also adapt processing_result below
+}
+
+messages = [Message(data={
+    'text': 'tölvupóst hjá steinari adolfssyni',
+    'message_id': '9f4b355fa6ca4e85936217fe8a4b27b7',
+    'metadata': None,
+    'text_tokens': [Token('tölvupóst', 0, 9), Token('hjá', 10, 13), Token('steinari', 14, 22),
+                    Token('adolfssyni', 23, 33)],
+    'intent': {'name': 'request_contact', 'confidence': 0.9999537467956543},
+    'entities': [
+        {'entity': 'email_or_phone', 'start': 0, 'end': 9, 'confidence_entity': 0.9997983574867249,
+         'value': 'tölvupóst', 'extractor': 'DIETClassifier'},
+        {'entity': 'contact', 'start': 14, 'end': 33, 'confidence_entity': 0.7713441848754883,
+         'value': 'steinari adolfssyni', 'extractor': 'DIETClassifier'}
+    ]
+})]
+
+match_entities_result = [
+    {
+        'entity': 'contact',
+        'start': 14,
+        'end': 33,
+        'confidence_entity': 1.0,
+        'value': 'steinari adolfssyni',
+        'extractor': 'BinEntityExtractor'
+    }
+]
+
+nlu_example_match_result = [
+    [
+        Token('tölvupóst', 0, 9),
+        Token('steinari', 14, 22),
+        Token('adolfssyni', 23, 33)
+    ]
+]
+
+processing_result = [
+    Message(data={'text': 'tölvupóst hjá steinari adolfssyni',
+                  'message_id': '9f4b355fa6ca4e85936217fe8a4b27b7',
+                  'metadata': None,
+                  'text_tokens': [Token('tölvupóst', 0, 9),
+                                  Token('hjá', 10, 13),
+                                  Token('steinari', 14,  22),
+                                  Token('adolfssyni', 23, 33)],
+                  'intent': {'name': 'request_contact', 'confidence': 0.9999537467956543},
+                  'entities': [{'entity': 'email_or_phone', 'start': 0, 'end': 9, 'confidence_entity': 0.9997983574867249,
+                                'value': 'tölvupóst', 'extractor': 'DIETClassifier'},
+                               {'entity': 'contact', 'start': 14, 'end': 33, 'confidence_entity': 0.7713441848754883,
+                                'value': 'steinari adolfssyni', 'extractor': 'DIETClassifier'},
+                               {'start': 14, 'end': 33, 'value': 'steinari adolfssyni', 'confidence_entity': 1.0,
+                                'entity': 'contact', 'extractor': 'BinEntityExtractor'}]})
+]
+
+
+def test_create():
+    bin_entity_extractor = BinEntityExtractor.create(
+        config=config,
+        model_storage=None,
+        resource=None,
+        execution_context=None
+    )
+    assert isinstance(bin_entity_extractor, BinEntityExtractor)
+
+
+def test_validate_component_config():
+    valid_config = config.copy()
+    invalid_config = config.copy()
+    invalid_config.pop('entity_mappings')  # making the config invalid
+
+    # Test with a valid config, should not raise an exception
+    try:
+        BinEntityExtractor.validate_component_config(valid_config)
+    except InvalidConfigException:
+        pytest.fail("validate_component_config raised InvalidConfigException unexpectedly!")
+
+    # Test with an invalid config, should raise an exception
+    with pytest.raises(InvalidConfigException):
+        BinEntityExtractor.validate_component_config(invalid_config)
+
+
+def test_match_entities():
+    extractor = BinEntityExtractor(config)
+    message = messages[0]
+    tokens = message.data["text_tokens"]
+
+    actual_result = extractor._match_entities(tokens, config['stop_words'])
+    expected_result = [match_entities_result[0]]
+    assert actual_result == expected_result, "The _match_entities function did not return the expected result."
+
+
+def test_nlu_example_match():
+    extractor = BinEntityExtractor(config)
+    message = messages[0]
+    tokens = message.get("text_tokens")
+    intent = message.get("intent")
+    message_text = message.get("text")
+
+    actual_result = extractor.nlu_example_match(tokens, intent, message_text)
+    expected_result = nlu_example_match_result[0]
+    assert actual_result == expected_result, "The nlu_example_match function did not return the expected result."
+
+
+def test_process():
+    bin_entity_extractor = BinEntityExtractor.create(
+        config=config,
+        model_storage=None,
+        resource=None,
+        execution_context=None
+    )
+
+    processed_messages = bin_entity_extractor.process(messages)
+
+    assert len(processed_messages) == 1
+    assert isinstance(processed_messages[0], Message)
+    actual_result = processed_messages[0].get('entities')
+    expected_result = processing_result[0].get('entities')
+    assert actual_result == expected_result, "The process function did not return the expected result."

--- a/config.yml
+++ b/config.yml
@@ -20,6 +20,16 @@ pipeline:
  - name: FallbackClassifier
    threshold: 0.7
  - name: EntitySynonymMapper
+ - name: classifiers.bin_entity_extractor.BinEntityExtractor
+   match_training_data: true
+   match_all_entities: false
+   entity_mappings:
+     contact:
+       - ism
+       - gæl
+       - föð
+       - móð
+       - erm
  - name: ResponseSelector
    epochs: 100
    retrieval_intent: faq

--- a/config.yml
+++ b/config.yml
@@ -23,6 +23,7 @@ pipeline:
  - name: classifiers.bin_entity_extractor.BinEntityExtractor
    match_training_data: true
    match_all_entities: false
+   use_stop_words: true
    entity_mappings:
      contact:
        - ism

--- a/config.yml
+++ b/config.yml
@@ -17,20 +17,9 @@ pipeline:
    model_weights: "grammatek/icelandic-ner-bert"
  - name: DIETClassifier
    epochs: 100
+ - name: EntitySynonymMapper
  - name: FallbackClassifier
    threshold: 0.7
- - name: EntitySynonymMapper
- - name: classifiers.bin_entity_extractor.BinEntityExtractor
-   match_training_data: true
-   match_all_entities: false
-   use_stop_words: true
-   entity_mappings:
-     contact:
-       - ism
-       - gæl
-       - föð
-       - móð
-       - erm
  - name: ResponseSelector
    epochs: 100
    retrieval_intent: faq

--- a/data/nlu.yml
+++ b/data/nlu.yml
@@ -365,6 +365,9 @@ nlu:
     - en hvað er [síminn]{"entity": "email_or_phone", "value": "phone"} hjá henni(pronoun)
     - er [hún](pronoun) líka með [netfang]{"entity": "email_or_phone", "value": "email"}
     - er [hann](pronoun) líka með [tölvupóst]{"entity": "email_or_phone", "value": "email"}
+    - [tölvupóst]{"entity": "email_or_phone", "value": "email"} hjá [Sigurði Ólafssyni](contact)
+    - [tölvupóst]{"entity": "email_or_phone", "value": "email"} hjá [Sigurði](contact)
+    - [tölvupóst]{"entity": "email_or_phone", "value": "email"} hjá [sigurði ólafssyni](contact)
 
 - intent: inform
   examples: |

--- a/docker/sdk/Dockerfile
+++ b/docker/sdk/Dockerfile
@@ -1,9 +1,9 @@
 FROM rasa/rasa-sdk:3.4.1
 USER root
 RUN pip install --upgrade pip
-RUN pip install --no-cache-dir --default-timeout=100 islenska==0.4.5
+RUN pip install --no-cache-dir --default-timeout=100 islenska==0.4.7
 RUN pip install --no-cache-dir pyyaml==6.0
-RUN pip install --no-cache-dir requests==2.26.0
+RUN pip install --no-cache-dir requests==2.31.0
 
 RUN mkdir -p /app/src
 COPY actions/actions.py /app/actions/actions.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,15 +1,15 @@
 # For actions
-islenska==0.4.6
+islenska==0.4.7
 pyyaml==6.0
-requests==2.28.2
+requests==2.31.0
 
 # Rasa dependencies
 freezegun==1.2.2
 keras==2.8.0
 Keras-Preprocessing==1.1.2
 numpy==1.22.4
-pytest==7.2.1
-pytest-asyncio==0.21.0
+pytest==7.4.0
+pytest-asyncio==0.21.1
 rdflib==6.3.2
 rasa==3.4.9
 rasa-sdk==3.4.1


### PR DESCRIPTION
Experimental entity extractor as a Rasa custom component that uses the BÍN database to extract
entities from the user input.

This extractor is currently disabled by default, but can be enabled by placing the configuration snippet
`classifiers/bin_config.yml` below the DIETClassifier configuration into the file `config.yml`.

The idea is to use the BÍN database to extract entities that are not covered by the DIETClassifier, such as names of
people, places, etc. The BÍN database is a large database of Icelandic words, their inflections and their grammatical
properties. The BÍN entity extractor can be customized to use mappings of entities to certain BÍN properties as
described here: https://bin.arnastofnun.is/gogn/storasnid/ord/.

One should also carefully place stop-words into the `stop_words` configuration parameter to avoid extracting entities that are not relevant or that are ambiguous as e.g. `á, dag, ...`

It should be placed behind all other entity extractors in the Rasa pipeline and be configured to either ignore or
replace already extracted entities, otherwise it will append the BÍN entities to the already extracted entities which
leads to double extracted entities. It can also be configured via the parameter `match_training_data` to extract only
entities that are labelled and where the user text closely follows the training data.

Please refer to the BÍN entity extractor configuration snippet for further details.