### PR TITLE
Update pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,16 @@ source venv/bin/activate
 pip install -r requirements.txt
 ```
 
+**note:**
+
+Currently, there is a bug when running `rasa interactive` in combination with the package `uvloop`, therefore, you need
+to uninstall `uvloop` before running `rasa interactive`:
+
+``` bash
+pip uninstall uvloop
+```
+
+#### Configuration files
 Rasa needs certain configuration files to be present. For local development, these are:
 
 ```
@@ -146,7 +156,7 @@ rasa test --endpoints config/endpoints.yml  --config config.yml -s tests/
 To run cross validations:
 
 ```bash
-rasa test --endpoints config/endpoints-standalone.yml  --config config.yml -s tests/ --cross-validation
+rasa test --endpoints config/endpoints.yml  --config config.yml -s tests/ --cross-validation
 ```
 
 This needs a long time, as there are multiple models trained and tested. All test and cross-validation results are

--- a/config.yml
+++ b/config.yml
@@ -7,16 +7,24 @@ pipeline:
  - name: LexicalSyntacticFeaturizer
  - name: RegexFeaturizer
  - name: CountVectorsFeaturizer
+   additional_vocabulary_size:
+     text: 1000
+   analyzer: word
+   OOV_token: oov
+   token_pattern: (?u)\b\w+\b
+   use_shared_vocab: true
+ - name: CountVectorsFeaturizer
    analyzer: char_wb
    min_ngram: 1
    max_ngram: 4
  - name: LanguageModelFeaturizer
-#   model_name: "convbert"
-#   model_weights: "jonfd/convbert-base-igc-is"
    model_name: "bert"
    model_weights: "grammatek/icelandic-ner-bert"
+   #model_weights: "sentence-transformers/LaBSE"
  - name: DIETClassifier
    epochs: 100
+   constrain_similarities: true
+   BILOU_flag: true
  - name: EntitySynonymMapper
  - name: FallbackClassifier
    threshold: 0.7
@@ -27,15 +35,21 @@ pipeline:
    epochs: 100
    retrieval_intent: chitchat
 policies:
-# # No configuration for policies was provided. The following default policies were used to train your model.
-# # If you'd like to customize them, uncomment and adjust the policies.
-# # See https://rasa.com/docs/rasa/policies for more information.
-#   - name: MemoizationPolicy
-#   - name: RulePolicy
-#   - name: UnexpecTEDIntentPolicy
-#     max_history: 5
-#     epochs: 100
-#   - name: TEDPolicy
-#     max_history: 5
-#     epochs: 100
-#     constrain_similarities: true
+ - name: MemoizationPolicy
+ - name: RulePolicy
+      # Confidence threshold for the `core_fallback_action_name` to apply.
+      # The action will apply if no other action was predicted with
+      # a confidence >= core_fallback_threshold. Note: core-threshold != nlu-threshold
+   core_fallback_threshold: 0.4
+   core_fallback_action_name: "action_default_fallback"
+   enable_fallback_prediction: true
+ - name: UnexpecTEDIntentPolicy
+   tolerance: 0.5
+   max_history: 5
+   epochs: 100
+   constrain_similarities: true
+ - name: TEDPolicy
+   max_history: 5
+   epochs: 100
+   constrain_similarities: true
+

--- a/data/nlu.yml
+++ b/data/nlu.yml
@@ -588,30 +588,7 @@ nlu:
   examples: |
     - stjórnsýslumál
     - persónuvernd
-- lookup: contact
-  examples: |
-    - Guðmundur Gunnarsson
-    - Sigurður
-    - guðmundur
-    - Gunnar Ólafsson
-    - gunnar ólafsson
-    - Gunnar
-    - Sigríður Kristín Gunnarsdóttir
-    - Sigríði Kristínu Gunnarsdóttur
-    - Sigríði Kristínu
-    - sigríði kristínu gunnarsdóttur
-    - sigríði kristínu
-    - Sigríði
-    - Kristín Margrét Ólafsdóttir
-    - Kristín M Ólafsd
-    - Kristínu Margréti Ólafsdóttur
-    - Kristínu Margréti
-    - kristín margrét
-    - kristínu margréti
-    - Ragnar Helgi Þorsteinsson
-    - Ragnar H
-    - Ragnar H Þorsteins
-    - Guðmundur B
+
 - lookup: title
   examples: |
     - bókari

--- a/data/stories/stories.yml
+++ b/data/stories/stories.yml
@@ -17,6 +17,24 @@ stories:
   - intent: bye
   - action: utter_bye
 
+- story: Out of scope
+  steps:
+  - intent: out_of_scope
+  - action: utter_out_of_scope
+
+- story: No input
+  steps:
+    - user: |
+
+      intent: no_intent
+    - action: utter_ask_rephrase
+
+- story: Activate two-stage fallback
+  steps:
+    - intent: nlu_fallback
+    - action: action_two_stage_fallback
+    - active_loop: action_two_stage_fallback
+
 - story: Get name for title
   steps:
   - intent: greet
@@ -49,10 +67,10 @@ stories:
   - action: utter_greet
   - intent: who_is
     entities:
-      - contact: "Jón"
+      - contact: "Jón Sigurðsson"
   - action: action_get_whois
   - slot_was_set:
-      - contact: "Jón Sigurðsson"
+      - title: "bæjarstjóri"
   - intent: thank
   - action: utter_thank
 
@@ -74,3 +92,32 @@ stories:
   - active_loop: null
   - intent: thank
   - action: utter_thank
+
+- story: Request contact, user mentions email preference and only email info is returned
+  steps:
+  - intent: request_contact
+    entities:
+    - email_or_phone: email
+    - contact: önnu
+  - slot_was_set:
+    - contact: önnu
+  - slot_was_set:
+    - email_or_phone: email
+  - action: request_contact_form
+  - active_loop: request_contact_form
+  - slot_was_set:
+    - contact: Anna Jónsdóttir
+  - slot_was_set:
+    - requested_slot: null
+  - slot_was_set:
+    - email_or_phone: email
+  - active_loop: null
+  - action: action_get_contact_info
+  - slot_was_set:
+    - contact: Anna Jónsdóttir
+  - slot_was_set:
+    - title: null
+  - slot_was_set:
+    - subject: null
+  - slot_was_set:
+    - pronoun: null

--- a/tests/test_stories.yml
+++ b/tests/test_stories.yml
@@ -133,13 +133,13 @@ stories:
           - active_loop: null
           - action: action_get_contact_info
 
-      - story: Request contact test, user mentions email preference and only email info is returned
+      - story:  Request contact test, user mentions email preference and only email info is returned
         steps:
           - intent: request_contact
-            user: |-
-              [tölvupóst]{"entity": "email_or_phone", "value": "email"} hjá [maríu jóhannsdóttur](contact)
+            user:  |-
+              [tölvupóst]{"entity": "email_or_phone", "value": "email"} hjá [Maríu Jóhannsdóttur](contact)
           - slot_was_set:
-              - contact: maríu jóhannsdóttur
+              - contact: Maríu Jóhannsdóttur
           - slot_was_set:
               - email_or_phone: email
           - action: request_contact_form
@@ -152,6 +152,14 @@ stories:
               - email_or_phone: email
           - active_loop: null
           - action: action_get_contact_info
+          - slot_was_set:
+              - contact: María Jóhannsdóttir
+          - slot_was_set:
+              - title: null
+          - slot_was_set:
+              - subject: null
+          - slot_was_set:
+              - pronoun: null
 
       - story: Activate request contact with inform and submit form test
         steps:


### PR DESCRIPTION
Add more training stories, correct test story, add word level Featurizer
    
## config.yml:
    
- add word level featurizer that adds bag-of-words features and possibility for OOV (out of vocabulary) NLU data. OOV is not yet used inside the project's NLU, though
- add completely written out pipeline, so that one can see explicitely what configuration is active
    
## data/stories/stories.yml:
    
- add more stories to balance test stories
    
## tests/test_stories.yml:
    
- correct the case of the name for one test story, because although `rasa interactive` correctly extracts the name independently of the case, the test stories seem to be more picky with intermediate slot results. Need to have an eye on that ...
- Also add more `slot_was_set` events
    
## data/nlu.yml:
    
- remove lookup of `contact` entity. This should be fully extracted by the pipieline's NLU entity extraction, otherwise it's hard to know, where extraction takes place